### PR TITLE
Detect GNUmakefile too

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example usage:
     -----> Compiling with Make
            gcc -o myapp myapp.c
 
-The buildpack will detect your app as C if it has the file `Makefile` in the root.  It will run a `configure` script if it exists in the root of the repository. It will then run `make` to compile the app.
+The buildpack will detect your app as C if it has the file `Makefile` or `GNUmakefile` in the root.  It will run a `configure` script if it exists in the root of the repository. It will then run `make` to compile the app.
 
 Hacking
 -------

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-if [[ -f $1/Makefile  ||  -f $1/configure ]]; then
+if [[ -f $1/Makefile  ||  -f $1/configure  ||  -f $1/GNUmakefile ]]; then
   echo "C" && exit 0
 else
   echo "no" && exit 1


### PR DESCRIPTION
Hi. The buildpack doesn't check for the existence of a GNUmakefile, which is a valid name for a makefile under GNU Make, but specific to GNU Make. A reason to use this file is, for example, if a project uses GNU Make extensions and a wishes to provide only GNUmakefile and leave the chance to create a more portable Makefile later.

According to the manual, GNU Make looks for Make files in the following order: GNUmakefile, makefile, Makefile.

I'm not sure if this is the correct fix and it is untested. What do you think? Comments and rejections welcome. Thanks.
